### PR TITLE
fix iteration count mismatch in JailBreaker.run()

### DIFF
--- a/prompt_hacker/attack/jailbreak.py
+++ b/prompt_hacker/attack/jailbreak.py
@@ -58,7 +58,7 @@ class JailBreaker(Attacker):
 
                 cnt += 1
                 if inputs.sample_size:
-                    if cnt > inputs.sample_size:
+                    if cnt >= inputs.sample_size:
                         break
 
             except KeyboardInterrupt:

--- a/prompt_hacker/attack/jailbreak.py
+++ b/prompt_hacker/attack/jailbreak.py
@@ -58,7 +58,7 @@ class JailBreaker(Attacker):
 
                 cnt += 1
                 if inputs.sample_size:
-                    if cnt >= inputs.sample_size:
+                    if cnt == inputs.sample_size:
                         break
 
             except KeyboardInterrupt:


### PR DESCRIPTION
fix iteration count mismatch in JailBreaker.run()